### PR TITLE
Streamlit app docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+Dockerfile
+docker-compose.yml
+venv/
+build/
+webapp_output/
+webapp_work/

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ MANIFEST
 .unison/
 .vscode/
 
+venv/
+*offsets.npz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM mambaorg/micromamba:1.5.8-jammy as base
+
+ARG GMX_VERSION=2023.4
+
+USER root
+
+RUN apt-get update && apt-get install -y wget gcc g++ make cmake
+
+RUN wget https://ftp.gromacs.org/gromacs/gromacs-$GMX_VERSION.tar.gz  -O /tmp/gromacs-$GMX_VERSION.tar.gz
+
+RUN tar -xzf /tmp/gromacs-$GMX_VERSION.tar.gz -C /tmp && \
+    cd /tmp/gromacs-$GMX_VERSION && \
+    mkdir build && cd build && \
+    cmake .. -DGMX_BUILD_OWN_FFTW=ON -DREGRESSIONTEST_DOWNLOAD=ON -DGMX_MPI=OFF && \
+    make -j 4 && make install && \
+    cd /tmp && rm -rf gromacs-$GMX_VERSION
+
+
+
+RUN echo "source /usr/local/gromacs/bin/GMXRC" >> /root/.bashrc
+WORKDIR /app
+
+COPY environment-app.yaml .
+
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+
+RUN micromamba install -n base -y -f environment-app.yaml
+
+COPY . /app
+
+RUN pip install --upgrade pip setuptools wheel
+
+RUN pip install .
+
+COPY entrypoint.sh /usr/local/bin/gmx_entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/_entrypoint.sh", "/usr/local/bin/gmx_entrypoint.sh"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM mambaorg/micromamba:1.5.8-jammy as base
 
-ARG GMX_VERSION=2023.4
-
 USER root
 
 RUN apt-get update && apt-get install -y wget gcc g++ make cmake
+
+ARG GMX_VERSION=2021.7
+ARG BUILD_JOBS=8
 
 RUN wget https://ftp.gromacs.org/gromacs/gromacs-$GMX_VERSION.tar.gz  -O /tmp/gromacs-$GMX_VERSION.tar.gz
 
@@ -12,8 +13,8 @@ RUN tar -xzf /tmp/gromacs-$GMX_VERSION.tar.gz -C /tmp && \
     cd /tmp/gromacs-$GMX_VERSION && \
     mkdir build && cd build && \
     cmake .. -DGMX_BUILD_OWN_FFTW=ON -DREGRESSIONTEST_DOWNLOAD=ON -DGMX_MPI=OFF && \
-    make -j 4 && make install && \
-    cd /tmp && rm -rf gromacs-$GMX_VERSION
+    make -j $BUILD_JOBS && make install && \
+    cd /tmp && rm -rf gromacs-$GMX_VERSION.*
 
 
 

--- a/README.md
+++ b/README.md
@@ -93,3 +93,48 @@ sible in the absence of the glycans, and 0 if a given site is not accessible at 
 can be then displayed e.g. in VMD:
 
 <img src="TUTORIAL/IMG/tut3.svg.png" width="500">
+
+## Running your own GlycoSHIELD web app
+
+### From source
+
+To run the GlycoSHIELD web app from source, you need create a conda environment with the necessary dependencies. You can do this by running:
+
+```bash
+conda env create --file=environment-app.yaml
+conda activate glycoshield
+conda install -c conda-forge gromacs
+```
+
+Then install the GlycoSHIELD package by running:
+
+```bash
+pip install .
+```
+
+After that you can run the app by running:
+
+
+```bash
+./run_streamlit.sh
+```
+
+Which will start the app on `localhost:8501`.
+
+### From Docker (recommended)
+
+If you have Docker installed, you can run the GlycoSHIELD web app using the provided Docker image, this image is based on micromamba image and contains all the necessary dependencies (including gromacs 2021.7 build from source)
+
+To run the app use docker-compose:
+
+```bash
+docker compose up -d
+```
+
+This will build the image and start the app on `localhost:8501`.
+
+In order to stop the app, run:
+
+```bash
+docker compose down
+```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,6 @@ services:
   web:
     build: .
     container_name: glycoshield-web
-    command: streamlit run  --server.headless true --browser.gatherUsageStats false --browser.serverAddress "127.0.0.1" Welcome.py
+    command: streamlit run --server.headless true --browser.gatherUsageStats false --browser.serverAddress "127.0.0.1" Welcome.py
     ports:
-      - "8000:8501"
+      - "8501:8501"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,7 @@
+services:
+  web:
+    build: .
+    container_name: glycoshield-web
+    command: streamlit run  --server.headless true --browser.gatherUsageStats false --browser.serverAddress "127.0.0.1" Welcome.py
+    ports:
+      - "8000:8501"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+source /usr/local/gromacs/bin/GMXRC
+# Execute the command passed to the container
+exec "$@"

--- a/environment-app.yaml
+++ b/environment-app.yaml
@@ -1,0 +1,18 @@
+name: glycoshield
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.11,<3.12
+  - pip>=21.3
+  - numpy
+  - scipy
+  - matplotlib
+  - mdanalysis
+  - streamlit
+  - nglview
+  - py3Dmol==2.0.0.post2
+  - ipywidgets==7.6.3
+  - ipython_genutils
+  - pip:
+    - st-click-detector
+    - stmol


### PR DESCRIPTION
Hi @matsikora , I noticed, that the project is missing Dockerfile for the web app and thought, that is could be useful for some people, so main changes here are:

- `Dockerfile` with `gromacs 2021.7` build from source (for some reason conda's pre-build gromacs is problematic to use in docker)
- `docker-compose.yaml` to run container from this image, with the default streamlit command from `run_streamlit.sh` and forward the port
- also I have based this image on slightly updated version of your environment (partially because originally, I thougt that file was missing and was not looking for it in the `binder` dir), this env works just fine for test examples

So I would be happy if you could review and accept this changes to make your tools even more usable!

P.S this version is more of a draft (could be probably improved with volumes and some other rearrangements, but I think, that is is a good starting point) 